### PR TITLE
Feature: add a `settle` flag to `act` method to prevent `pumpAndSettle`

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/find.dart
+++ b/packages/convenient_test_dev/lib/src/functions/find.dart
@@ -188,6 +188,7 @@ class TFinderCommand extends TCommand {
     required Future<void> Function(LogHandle log) act,
     required String logTitle,
     required String logMessage,
+    bool settle = true,
   }) async {
     final log = t.log(logTitle, logMessage);
 
@@ -209,7 +210,7 @@ class TFinderCommand extends TCommand {
 
     await act(log);
 
-    await t.pumpAndSettle();
+    settle ? await t.pumpAndSettle() : await t.pump();
 
     await log.snapshot(name: 'after');
   }


### PR DESCRIPTION
Closes #249 

This PR adds a new optional flag to `act` method to call`pump` instead of `pumpAndSettle` in case the widget under test would never settle (example would be any widget containing a looping animation)
