### PR TITLE
WIP Auto detect AVD

### DIFF
--- a/packages/convenient_test_common_dart/lib/src/consts.dart
+++ b/packages/convenient_test_common_dart/lib/src/consts.dart
@@ -6,3 +6,5 @@ const kWorkerVmServiceHost = '127.0.0.1';
 const kWorkerVmServicePort = 9753;
 
 const kReportFileExtension = 'bin';
+
+const kAutoDetectAVD = true;

--- a/packages/convenient_test_dev/lib/src/functions/core.dart
+++ b/packages/convenient_test_dev/lib/src/functions/core.dart
@@ -13,6 +13,7 @@ import 'package:convenient_test_dev/src/support/manager_rpc_service.dart';
 import 'package:convenient_test_dev/src/support/setup.dart';
 import 'package:convenient_test_dev/src/support/slot.dart';
 import 'package:convenient_test_dev/src/third_party/my_test_compat.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
@@ -52,6 +53,13 @@ class ConvenientTest {
 /// Please make this the only method in your "main" method.
 Future<void> convenientTestMain(ConvenientTestSlot slot, VoidCallback testBody) async {
   myGetIt.registerSingleton<ConvenientTestSlot>(slot);
+
+  await runZonedGuarded(() async {
+    MyIntegrationTestWidgetsFlutterBinding();
+    myGetIt
+        .registerSingleton<BaseDeviceInfo>(await DeviceInfoPlugin().deviceInfo);
+  }, (_, __) {});
+
   // MUST do it this early, because we really need the rpc client immediately
   myGetIt.registerSingleton<ConvenientTestManagerClient>(ExtConvenientTestManagerClient.create());
 

--- a/packages/convenient_test_dev/lib/src/support/manager_rpc_service.dart
+++ b/packages/convenient_test_dev/lib/src/support/manager_rpc_service.dart
@@ -1,10 +1,23 @@
 import 'package:convenient_test_common/convenient_test_common.dart';
+import 'package:convenient_test_dev/src/support/get_it.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:grpc/grpc.dart';
 
 extension ExtConvenientTestManagerClient on ConvenientTestManagerClient {
   static ConvenientTestManagerClient create() {
+    String managerHostAddr = kConvenientTestManagerHost;
+
+    final deviceInfoMap = myGetIt.get<BaseDeviceInfo>().toMap();
+    if (deviceInfoMap.containsKey('isPhysicalDevice') &&
+        !(deviceInfoMap['isPhysicalDevice'] as bool) &&
+        kAutoDetectAVD) {
+      Log.i('gRPCSetup',
+          'Android Virtual Device Detected. Overriding host address with 10.0.2.2');
+      managerHostAddr = '10.0.2.2';
+    }
+
     final channel = ClientChannel(
-      kConvenientTestManagerHost,
+      managerHostAddr,
       port: kConvenientTestManagerPort,
       options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
     );

--- a/packages/convenient_test_dev/pubspec.yaml
+++ b/packages/convenient_test_dev/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   recase: ^4.0.0
   test_api: ^0.4.2
   web_socket_channel: ^2.1.0
+  device_info_plus: ^3.2.1 #Can't be set to newest version due to dart_vlc ffi: 1.0.0 requirement
 
 dev_dependencies:
   build_runner: ^2.1.2
@@ -39,10 +40,12 @@ dev_dependencies:
   freezed: ^2.0.0
   json_serializable: ^6.1.5
 
-# dependency_overrides:
-#   convenient_test:
-#     path: ../convenient_test
-#   convenient_test_common:
-#     path: ../convenient_test_common
-#   convenient_test_common_dart:
-#     path: ../convenient_test_common_dart
+dependency_overrides:
+  convenient_test:
+    path: ../convenient_test
+  convenient_test_common:
+    path: ../convenient_test_common
+  convenient_test_common_dart:
+    path: ../convenient_test_common_dart
+  # device_info_plus: '4.0.0'
+  # device_info_plus_platform_interface: '2.3.0+1'

--- a/packages/convenient_test_manager/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/convenient_test_manager/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,14 +5,14 @@
 import FlutterMacOS
 import Foundation
 
-import dart_vlc
+import device_info_plus_macos
 import path_provider_macos
 import screen_retriever
 import window_manager
 import window_size
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  DartVlcPlugin.register(with: registry.registrar(forPlugin: "DartVlcPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/packages/convenient_test_manager/pubspec.yaml
+++ b/packages/convenient_test_manager/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   convenient_test_dev: ^1.0.0
   convenient_test_manager_dart: ^1.0.0
   cupertino_icons: ^1.0.2
-  dart_vlc: ^0.2.0
+  dart_vlc: ^0.3.0
   file_picker: ^4.5.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
Added a starter branch for auto detecting AVD.

The problem is that we need a WidgetsBinding before we can detect if we are running in an AVD. 

This code currently causes problems when the client performs a hot restart because there is more than one widgetsBinding already initialized.

The PR is only for reference or for someone else to fix later on.

closes #253