### PR TITLE
fix: flag to prevent pumpAndSettle for other commands

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/find.dart
+++ b/packages/convenient_test_dev/lib/src/functions/find.dart
@@ -123,14 +123,21 @@ class TFinderCommand extends TCommand {
   @override
   Object? getCurrentActual() => finder;
 
-  Future<void> replaceText(String text, {bool settle = true,}) => act(
+  Future<void> replaceText(
+    String text, {
+    bool settle = true,
+  }) =>
+      act(
         act: (log) => t.tester.enterText(finder, text),
         logTitle: 'REPLACE TYPE',
         logMessage: '"$text" to ${finder.description}',
         settle: settle,
       );
 
-  Future<void> enterTextWithoutReplace(String text, {bool settle = true,}}) {
+  Future<void> enterTextWithoutReplace(
+    String text, {
+    bool settle = true,
+  }) {
     const logTitle = 'TYPE';
     final basicLogMessage = '"$text" to ${finder.description}';
 
@@ -148,21 +155,34 @@ class TFinderCommand extends TCommand {
     );
   }
 
-  Future<void> tap({bool warnIfMissed = true, bool settle = true,}) => act(
+  Future<void> tap({
+    bool warnIfMissed = true,
+    bool settle = true,
+  }) =>
+      act(
         act: (log) => t.tester.tap(finder, warnIfMissed: warnIfMissed),
         logTitle: 'TAP',
         logMessage: finder.description,
         settle: settle,
       );
 
-  Future<void> longPress({bool warnIfMissed = true, bool settle = true,}) => act(
+  Future<void> longPress({
+    bool warnIfMissed = true,
+    bool settle = true,
+  }) =>
+      act(
         act: (log) => t.tester.longPress(finder, warnIfMissed: warnIfMissed),
         logTitle: 'LONG PRESS',
         logMessage: finder.description,
         settle: settle,
       );
 
-  Future<void> drag(Offset offset, {bool warnIfMissed = true, bool settle = true,}) => act(
+  Future<void> drag(
+    Offset offset, {
+    bool warnIfMissed = true,
+    bool settle = true,
+  }) =>
+      act(
         act: (log) => t.tester.drag(finder, offset, warnIfMissed: warnIfMissed),
         logTitle: 'DRAG',
         logMessage: finder.description,

--- a/packages/convenient_test_dev/lib/src/functions/find.dart
+++ b/packages/convenient_test_dev/lib/src/functions/find.dart
@@ -123,13 +123,14 @@ class TFinderCommand extends TCommand {
   @override
   Object? getCurrentActual() => finder;
 
-  Future<void> replaceText(String text) => act(
+  Future<void> replaceText(String text, {bool settle = true,}) => act(
         act: (log) => t.tester.enterText(finder, text),
         logTitle: 'REPLACE TYPE',
         logMessage: '"$text" to ${finder.description}',
+        settle: settle,
       );
 
-  Future<void> enterTextWithoutReplace(String text) {
+  Future<void> enterTextWithoutReplace(String text, {bool settle = true,}}) {
     const logTitle = 'TYPE';
     final basicLogMessage = '"$text" to ${finder.description}';
 
@@ -143,25 +144,29 @@ class TFinderCommand extends TCommand {
       ),
       logTitle: logTitle,
       logMessage: basicLogMessage,
+      settle: settle,
     );
   }
 
-  Future<void> tap({bool warnIfMissed = true}) => act(
+  Future<void> tap({bool warnIfMissed = true, bool settle = true,}) => act(
         act: (log) => t.tester.tap(finder, warnIfMissed: warnIfMissed),
         logTitle: 'TAP',
         logMessage: finder.description,
+        settle: settle,
       );
 
-  Future<void> longPress({bool warnIfMissed = true}) => act(
+  Future<void> longPress({bool warnIfMissed = true, bool settle = true,}) => act(
         act: (log) => t.tester.longPress(finder, warnIfMissed: warnIfMissed),
         logTitle: 'LONG PRESS',
         logMessage: finder.description,
+        settle: settle,
       );
 
-  Future<void> drag(Offset offset, {bool warnIfMissed = true}) => act(
+  Future<void> drag(Offset offset, {bool warnIfMissed = true, bool settle = true,}) => act(
         act: (log) => t.tester.drag(finder, offset, warnIfMissed: warnIfMissed),
         logTitle: 'DRAG',
         logMessage: finder.description,
+        settle: settle,
       );
 
   Future<void> multiDrag({
@@ -170,6 +175,7 @@ class TFinderCommand extends TCommand {
     required List<Offset> firstFingerOffsets,
     required List<Offset> secondFingerOffsets,
     bool? logMove,
+    bool settle = true,
   }) =>
       act(
         act: (log) => t.tester.multiDrag(
@@ -182,6 +188,7 @@ class TFinderCommand extends TCommand {
         ),
         logTitle: 'MULTI DRAG',
         logMessage: finder.description,
+        settle: settle,
       );
 
   Future<void> act({


### PR DESCRIPTION
https://github.com/fzyzcjy/flutter_convenient_test/pull/252 add flag to prevent pumpAndSettle.
This should be added to other TFinderCommand as well. 