### PR TITLE
Adds a settle argument to tTestWidgets.

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/core.dart
+++ b/packages/convenient_test_dev/lib/src/functions/core.dart
@@ -160,19 +160,24 @@ Future<void> _lastTearDownAll() async {
 
 typedef TWidgetTesterCallback = Future<void> Function(ConvenientTest t);
 
+/// Wrapper around [testWidgets].
+///
+/// If the app's main widget contains a widget that never settles (for example:
+/// has animations that repeats infinitely), set [settle] to false.
 @isTest
 void tTestWidgets(
   // ... forward the arguments ...
   String description,
   TWidgetTesterCallback callback, {
   bool skip = false,
+  bool settle = true,
 }) {
   testWidgets(
     description,
     (tester) async => await ConvenientTest.withActiveInstance(tester, (t) async {
       final log = t.log('START APP', '');
       await myGetIt.get<ConvenientTestSlot>().appMain(AppMainExecuteMode.integrationTest);
-      await t.pumpAndSettle();
+      settle ? await t.pumpAndSettle() : await t.pump();
       await log.snapshot(name: 'after');
 
       await callback(t);

--- a/packages/convenient_test_dev/lib/src/functions/core.dart
+++ b/packages/convenient_test_dev/lib/src/functions/core.dart
@@ -163,7 +163,7 @@ typedef TWidgetTesterCallback = Future<void> Function(ConvenientTest t);
 /// Wrapper around [testWidgets].
 ///
 /// If the app's main widget contains a widget that never settles (for example:
-/// has animations that repeats infinitely), set [settle] to false.
+/// has animations that repeat infinitely), set [settle] to false.
 @isTest
 void tTestWidgets(
   // ... forward the arguments ...


### PR DESCRIPTION
Fixes #272 
Adds a flag to tTestWidgets to control whether pumpAndSettle() or pump() is called. 