### PR TITLE
Fix dependency resolution issues and improve Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,8 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7.2"
+          ruby-version: "3.1.2"
+          bundler-cache: true
 
       - name: setup-cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: "0 10 * * *"
 
 jobs:
   flutter:
@@ -13,9 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel:
-          # - beta # too different from stable, thus analyzer will complain
-          - stable
+        include:
+          - version: 3.0.0
+          - channel: stable
+          - channel: beta
         package_name:
           - convenient_test
           - convenient_test/example
@@ -28,10 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
-          flutter-version: '3.0.5' # TODO upgrade later
+          flutter-version: ${{ matrix.version }}
 
       - name: Install dependencies
         run: flutter pub get
@@ -53,9 +54,8 @@ jobs:
         run: flutter format --set-exit-if-changed --line-length 120 .
         working-directory: packages/${{ matrix.package_name }}
 
-
   build_manager_macos:
-    runs-on: macOS-11
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2
@@ -64,8 +64,8 @@ jobs:
         with:
           channel: stable
           architecture: x64
-          flutter-version: '3.0.5' # TODO upgrade later
-      
+          flutter-version: "3.0.5" # TODO upgrade later
+
       - name: Enable Macos
         run: flutter config --enable-macos-desktop
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.2'
+          ruby-version: "2.7.2"
 
       - name: setup-cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1
@@ -98,7 +98,6 @@ jobs:
           name: manager_macos
           path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
 
-          
   build_manager_linux:
     runs-on: ubuntu-latest
 
@@ -109,7 +108,7 @@ jobs:
         with:
           channel: stable
           architecture: x64
-          flutter-version: '3.0.5' # TODO upgrade later
+          flutter-version: "3.0.5" # TODO upgrade later
 
       - name: Enable Linux
         run: |
@@ -144,7 +143,7 @@ jobs:
         with:
           channel: stable
           architecture: x64
-          flutter-version: '3.0.5' # TODO upgrade later
+          flutter-version: "3.0.5" # TODO upgrade later
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,15 +8,12 @@ on:
 
 jobs:
   flutter:
+    name: ${{ matrix.package_name }} on Flutter ${{ matrix.channel }}${{ matrix.version }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: 3.0.0
-          - channel: stable
-          - channel: beta
         package_name:
           - convenient_test
           - convenient_test/example
@@ -25,11 +22,18 @@ jobs:
           - convenient_test_dev
           - convenient_test_manager
           - convenient_test_manager_dart
+        version: ["3.0.0", ""]
+        channel: [stable, beta, ""]
+        exclude:
+          - { version: "3.0.0", channel: "stable" }
+          - { version: "3.0.0", channel: "beta" }
+          - { version: "", channel: "" }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: subosito/flutter-action@v2
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.channel }}
           flutter-version: ${{ matrix.version }}
@@ -58,13 +62,12 @@ jobs:
     runs-on: macos-11
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          architecture: x64
-          flutter-version: "3.0.5" # TODO upgrade later
+          flutter-version: "3.3.2"
 
       - name: Enable Macos
         run: flutter config --enable-macos-desktop
@@ -102,13 +105,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          architecture: x64
-          flutter-version: "3.0.5" # TODO upgrade later
+          flutter-version: "3.3.2"
 
       - name: Enable Linux
         run: |
@@ -137,13 +139,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          architecture: x64
-          flutter-version: "3.0.5" # TODO upgrade later
+          flutter-version: "3.3.2"
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   flutter:
-    name: ${{ matrix.package_name }} on Flutter ${{ matrix.channel }}${{ matrix.version }}
+    name: ${{ matrix.package_name }} on Flutter ${{ matrix.channel_version.channel }}${{ matrix.channel_version.version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -22,12 +22,10 @@ jobs:
           - convenient_test_dev
           - convenient_test_manager
           - convenient_test_manager_dart
-        version: ["3.0.0", ""]
-        channel: [stable, beta, ""]
-        exclude:
-          - { version: "3.0.0", channel: "stable" }
-          - { version: "3.0.0", channel: "beta" }
-          - { version: "", channel: "" }
+        channel_version:
+          - { channel: stable }
+          - { channel: beta }
+          - { version: "3.0.0" }
 
     steps:
       - uses: actions/checkout@v3
@@ -35,8 +33,8 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: ${{ matrix.channel }}
-          flutter-version: ${{ matrix.version }}
+          channel: ${{ matrix.channel_version.channel }}
+          flutter-version: ${{ matrix.channel_version.version }}
 
       - name: Install dependencies
         run: flutter pub get

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,1 @@
+{ "dart.lineLength": 120 }

--- a/packages/convenient_test/example/pubspec.yaml
+++ b/packages/convenient_test/example/pubspec.yaml
@@ -3,10 +3,11 @@ description: Demonstrates how to use the convenient_test plugin.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -44,7 +45,6 @@ dependency_overrides:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/convenient_test/lib/src/gesture_visualizer.dart
+++ b/packages/convenient_test/lib/src/gesture_visualizer.dart
@@ -12,7 +12,7 @@ const _kRemainAfterPointerUp = Duration(milliseconds: 100);
 /// It does not matter to this widget whether the child accepts the hit events.
 /// Everything hitting the rect of the child will be recorded.
 class GestureVisualizer extends SingleChildRenderObjectWidget {
-  const GestureVisualizer({Key? key, required Widget child}) : super(key: key, child: child);
+  const GestureVisualizer({super.key, required Widget super.child});
 
   @override
   RenderObject createRenderObject(BuildContext context) {

--- a/packages/convenient_test/lib/src/misc.dart
+++ b/packages/convenient_test/lib/src/misc.dart
@@ -136,10 +136,7 @@ class Mark extends StatelessWidget {
   }
 
   String _onlyUpperOrFirstLetter(String s) {
-    return s
-        .split('')
-        .whereIndexed((i, ch) => i == 0 || ch.toUpperCase() == ch)
-        .join('');
+    return s.split('').whereIndexed((i, ch) => i == 0 || ch.toUpperCase() == ch).join('');
   }
 }
 

--- a/packages/convenient_test/lib/src/misc.dart
+++ b/packages/convenient_test/lib/src/misc.dart
@@ -7,7 +7,7 @@ class ConvenientTestWrapperWidget extends StatelessWidget {
 
   static var convenientTestActive = false;
 
-  const ConvenientTestWrapperWidget({Key? key, required this.child}) : super(key: key);
+  const ConvenientTestWrapperWidget({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +23,7 @@ class ConvenientTestWrapperWidget extends StatelessWidget {
 class ConvenientTestImageCaptureWrapper extends StatelessWidget {
   final Widget child;
 
-  const ConvenientTestImageCaptureWrapper({Key? key, required this.child}) : super(key: key);
+  const ConvenientTestImageCaptureWrapper({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {
@@ -41,11 +41,11 @@ class MarkCore extends StatelessWidget {
   final Widget child;
 
   const MarkCore({
-    Key? key,
+    super.key,
     required this.name,
     this.data,
     required this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) => child;
@@ -64,19 +64,21 @@ class Mark extends StatelessWidget {
   final Widget child;
 
   const Mark({
-    Key? key,
+    super.key,
     this.enable = true,
     required this.name,
     this.repaintBoundary = false,
     this.data,
     required this.child,
-  }) : super(key: key);
+  });
 
   T childTyped<T>() => child as T;
 
   @override
   Widget build(BuildContext context) {
-    if (!enable || !ConvenientTestWrapperWidget.convenientTestActive) return child;
+    if (!enable || !ConvenientTestWrapperWidget.convenientTestActive) {
+      return child;
+    }
 
     final color = kColorList['$name'.hashCode % kColorList.length];
 
@@ -134,7 +136,10 @@ class Mark extends StatelessWidget {
   }
 
   String _onlyUpperOrFirstLetter(String s) {
-    return s.split('').whereIndexed((i, ch) => i == 0 || ch.toUpperCase() == ch).join('');
+    return s
+        .split('')
+        .whereIndexed((i, ch) => i == 0 || ch.toUpperCase() == ch)
+        .join('');
   }
 }
 

--- a/packages/convenient_test/pubspec.yaml
+++ b/packages/convenient_test/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.1.1
 repository: https://github.com/fzyzcjy/flutter_convenient_test
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
+++ b/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:convenient_test_common_dart/convenient_test_common_dart.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+// ignore: unnecessary_import
 import 'package:flutter/physics.dart';
 
 // ignore_for_file: omit_local_variable_types, curly_braces_in_flow_control_structures

--- a/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
+++ b/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
@@ -3,7 +3,6 @@ import 'dart:math';
 import 'package:convenient_test_common_dart/convenient_test_common_dart.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
 
 // ignore_for_file: omit_local_variable_types, curly_braces_in_flow_control_structures
 

--- a/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
+++ b/packages/convenient_test_common/lib/src/common_flutter/non_ballistic_clamping_scroll_physics.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:convenient_test_common_dart/convenient_test_common_dart.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
 
 // ignore_for_file: omit_local_variable_types, curly_braces_in_flow_control_structures
 

--- a/packages/convenient_test_common/pubspec.yaml
+++ b/packages/convenient_test_common/pubspec.yaml
@@ -3,7 +3,8 @@ description: Write and debug tests easily, with full action history, time travel
 version: 1.1.1
 repository: https://github.com/fzyzcjy/flutter_convenient_test
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 dependencies:
   collection: ^1.15.0
   convenient_test_common_dart: ^1.0.0
@@ -20,7 +21,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   lint: ^1.8.2
-
 # dependency_overrides:
 #   convenient_test_common_dart:
 #     path: ../convenient_test_common_dart

--- a/packages/convenient_test_common_dart/lib/src/my_analysis_options.yaml
+++ b/packages/convenient_test_common_dart/lib/src/my_analysis_options.yaml
@@ -4,9 +4,9 @@ include: package:lint/analysis_options.yaml
 
 # https://dart.dev/guides/language/analysis-options
 analyzer:
-# will use CI to check. this plugin will leak memory
-#   plugins:
-#     - dart_code_metrics
+  # will use CI to check. this plugin will leak memory
+  #   plugins:
+  #     - dart_code_metrics
 
   language:
     strict-casts: true
@@ -46,9 +46,9 @@ dart_code_metrics:
     - avoid-unnecessary-setstate
     - avoid-collection-methods-with-unrelated-types
     - tag-name:
-        var-names: [ _kTag, tag, kTag, TAG ]
-        strip-prefix: '_'
-        strip-postfix: 'State'
+        var-names: [_kTag, tag, kTag, TAG]
+        strip-prefix: "_"
+        strip-postfix: "State"
   anti-patterns:
     - long-method
 

--- a/packages/convenient_test_common_dart/pubspec.yaml
+++ b/packages/convenient_test_common_dart/pubspec.yaml
@@ -3,7 +3,7 @@ description: Write and debug tests easily, with full action history, time travel
 version: 1.1.1
 repository: https://github.com/fzyzcjy/flutter_convenient_test
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 dependencies:
   collection: ^1.15.0
   fixnum: ^1.0.0

--- a/packages/convenient_test_dev/lib/src/functions/goldens.dart
+++ b/packages/convenient_test_dev/lib/src/functions/goldens.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert' hide Codec;
 import 'dart:math';
 import 'dart:math' as math;
-import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:convenient_test_common/convenient_test_common.dart';

--- a/packages/convenient_test_dev/lib/src/functions/goldens.dart
+++ b/packages/convenient_test_dev/lib/src/functions/goldens.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert' hide Codec;
 import 'dart:math';
 import 'dart:math' as math;
+import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:convenient_test_common/convenient_test_common.dart';

--- a/packages/convenient_test_dev/lib/src/functions/goldens.dart
+++ b/packages/convenient_test_dev/lib/src/functions/goldens.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert' hide Codec;
 import 'dart:math';
 import 'dart:math' as math;
+// ignore: unnecessary_import
 import 'dart:typed_data';
 import 'dart:ui';
 

--- a/packages/convenient_test_dev/lib/src/functions/interaction.dart
+++ b/packages/convenient_test_dev/lib/src/functions/interaction.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:convenient_test_dev/src/functions/core.dart';
@@ -6,7 +7,6 @@ import 'package:convenient_test_dev/src/support/get_it.dart';
 import 'package:convenient_test_dev/src/support/slot.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pedantic/pedantic.dart';
 
 extension ConvenientTestInteraction on ConvenientTest {
   Future<void> visit(String routeName, {Object? arguments}) async {

--- a/packages/convenient_test_dev/pubspec.yaml
+++ b/packages/convenient_test_dev/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/fzyzcjy/flutter_convenient_test
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   collection: ^1.15.0
@@ -38,7 +39,6 @@ dev_dependencies:
   dart_code_metrics: ^4.15.0
   freezed: ^2.0.0
   json_serializable: ^6.1.5
-
 # dependency_overrides:
 #   convenient_test:
 #     path: ../convenient_test

--- a/packages/convenient_test_dev/pubspec.yaml
+++ b/packages/convenient_test_dev/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   meta: ^1.3.0
   path: ^1.8.0
   path_provider: ^2.0.9
-  pedantic: ^1.11.0
   recase: ^4.0.0
   test_api: ^0.4.2
   web_socket_channel: ^2.1.0

--- a/packages/convenient_test_manager/pubspec.yaml
+++ b/packages/convenient_test_manager/pubspec.yaml
@@ -3,7 +3,7 @@ description: Write and debug tests easily, with full action history, time travel
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.1.1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0
@@ -49,7 +49,7 @@ dependencies:
   scrollable_positioned_list: ^0.3.2
   test_api: ^0.4.2
   tuple: ^2.0.0
-  vm_service: ^8.0.0
+  vm_service: ^9.0.0
   window_size:
     git:
       url: https://github.com/google/flutter-desktop-embedding
@@ -73,7 +73,6 @@ dependency_overrides:
 dev_dependencies:
   analyzer: ^2.3.0
   build_runner: ^2.1.2
-  build_test: ^2.0.0
   dart_code_metrics: ^4.15.0
   lint: ^1.8.2
   mobx_codegen: ^2.0.6
@@ -83,7 +82,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/convenient_test_manager/pubspec.yaml
+++ b/packages/convenient_test_manager/pubspec.yaml
@@ -19,6 +19,7 @@ version: 1.1.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   collection: ^1.15.0
@@ -49,7 +50,6 @@ dependencies:
   scrollable_positioned_list: ^0.3.2
   test_api: ^0.4.2
   tuple: ^2.0.0
-  vm_service: ^9.0.0
   window_size:
     git:
       url: https://github.com/google/flutter-desktop-embedding

--- a/packages/convenient_test_manager_dart/pubspec.yaml
+++ b/packages/convenient_test_manager_dart/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   mobx: ^2.0.6
   recase: ^4.0.0
   test_api: ^0.4.2
-  vm_service: ^9.0.0
+  vm_service: any
 
 dependency_overrides:
   convenient_test_common_dart:

--- a/packages/convenient_test_manager_dart/pubspec.yaml
+++ b/packages/convenient_test_manager_dart/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   pedantic: ^1.11.0
   recase: ^4.0.0
   test_api: ^0.4.2
-  vm_service: ^9.0.0
+  vm_service: ^8.0.0
 
 dependency_overrides:
   convenient_test_common_dart:

--- a/packages/convenient_test_manager_dart/pubspec.yaml
+++ b/packages/convenient_test_manager_dart/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   pedantic: ^1.11.0
   recase: ^4.0.0
   test_api: ^0.4.2
-  vm_service: ^8.0.0
+  vm_service: ^9.0.0
 
 dependency_overrides:
   convenient_test_common_dart:
@@ -31,7 +31,6 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.1.2
-  build_test: ^2.0.0
   dart_code_metrics: ^4.15.0
   freezed: ^2.0.3
   json_serializable: ^6.2.0

--- a/packages/convenient_test_manager_dart/pubspec.yaml
+++ b/packages/convenient_test_manager_dart/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   mobx: ^2.0.6
   recase: ^4.0.0
   test_api: ^0.4.2
-  vm_service: any
+  vm_service: ">=8.0.0 <10.0.0"
 
 dependency_overrides:
   convenient_test_common_dart:

--- a/packages/convenient_test_manager_dart/pubspec.yaml
+++ b/packages/convenient_test_manager_dart/pubspec.yaml
@@ -17,10 +17,9 @@ dependencies:
   intl: ^0.17.0
   meta: ^1.3.0
   mobx: ^2.0.6
-  pedantic: ^1.11.0
   recase: ^4.0.0
   test_api: ^0.4.2
-  vm_service: ^8.0.0
+  vm_service: ^9.0.0
 
 dependency_overrides:
   convenient_test_common_dart:


### PR DESCRIPTION
I cloned the repository and run `flutter pub get` in all packages.

I encountered the following problem with dependencies in `convenient_test_manager`:

```
[packages/convenient_test_manager] flutter pub get
Running "flutter pub get" in convenient_test_manager...         
Because every version of convenient_test_dev from path depends on integration_test from sdk which depends on vm_service 9.0.0, every version of convenient_test_dev from path requires vm_service 9.0.0.
So, because convenient_test_manager depends on both vm_service ^8.0.0 and convenient_test_dev from path, version solving failed.
pub get failed (1; So, because convenient_test_manager depends on both vm_service ^8.0.0 and convenient_test_dev from path, version solving failed.)
exit code 1
```

This PR fixes these dependency resolution problem, and also improves `ci.yaml` Action to verify that this package can be used on all supported Flutter versions.