### PR TITLE
Ignore the VLC Video component on MacOS(Apple Silicon) 

### DIFF
--- a/packages/convenient_test_manager/lib/components/home_page/video_panel.dart
+++ b/packages/convenient_test_manager/lib/components/home_page/video_panel.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:convenient_test_manager/components/misc/video_player.dart';
 import 'package:convenient_test_manager/stores/video_player_store.dart';
 import 'package:flutter/material.dart';
@@ -21,6 +23,10 @@ class HomePageVideoPanel extends StatelessWidget {
             // https://github.com/fzyzcjy/flutter_convenient_test/issues/217#issuecomment-1133922630
             'Remark: If your (toy) tests are too short, videos may not be recorded.',
           ),
+        );
+      } else if (Platform.isMacOS) {
+        return const Center(
+          child: Text('MacOS does not yet support video playback'),
         );
       }
 

--- a/packages/convenient_test_manager/lib/misc/setup.dart
+++ b/packages/convenient_test_manager/lib/misc/setup.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:convenient_test_common/convenient_test_common.dart';
 import 'package:convenient_test_manager/services/fs_service.dart';
 import 'package:convenient_test_manager/services/misc_flutter_service.dart';
@@ -5,7 +7,8 @@ import 'package:convenient_test_manager/stores/golden_diff_page_store.dart';
 import 'package:convenient_test_manager/stores/highlight_store.dart';
 import 'package:convenient_test_manager/stores/home_page_store.dart';
 import 'package:convenient_test_manager/stores/video_player_store.dart';
-import 'package:convenient_test_manager_dart/misc/setup.dart' as convenient_test_manager_dart_setup;
+import 'package:convenient_test_manager_dart/misc/setup.dart'
+    as convenient_test_manager_dart_setup;
 import 'package:convenient_test_manager_dart/services/fs_service.dart';
 import 'package:convenient_test_manager_dart/services/misc_dart_service.dart';
 import 'package:convenient_test_manager_dart/stores/highlight_store.dart';
@@ -25,7 +28,7 @@ Future<void> setup() async {
     registerVideoPlayerStoreBase: false,
   );
 
-  await DartVLC.initialize();
+  if (!Platform.isMacOS) DartVLC.initialize();
 
   await _setWindowSize();
 
@@ -37,7 +40,8 @@ Future<void> setup() async {
   getIt.registerSingleton<MiscFlutterService>(MiscFlutterService());
 
   getIt.registerSingleton<HighlightStoreBase>(GetIt.I.get<HighlightStore>());
-  getIt.registerSingleton<VideoPlayerStoreBase>(GetIt.I.get<VideoPlayerStore>());
+  getIt
+      .registerSingleton<VideoPlayerStoreBase>(GetIt.I.get<VideoPlayerStore>());
   getIt.registerSingleton<MiscDartService>(GetIt.I.get<MiscFlutterService>());
 }
 
@@ -50,7 +54,8 @@ Future<void> _setWindowSize() async {
   // https://github.com/flutter/flutter/issues/30736#issuecomment-706977876
   final window = await window_size.getWindowInfo();
   final screen = window.screen;
-  Log.d(_kTag, 'window=${window.customToString()} screen=${screen?.customToString()}');
+  Log.d(_kTag,
+      'window=${window.customToString()} screen=${screen?.customToString()}');
   if (screen != null) {
     const width = 1350.0;
     const height = 1000.0;
@@ -67,9 +72,11 @@ Future<void> _setWindowSize() async {
 }
 
 extension on window_size.PlatformWindow {
-  String customToString() => 'PlatformWindow{frame: $frame, scaleFactor: $scaleFactor, screen: $screen}';
+  String customToString() =>
+      'PlatformWindow{frame: $frame, scaleFactor: $scaleFactor, screen: $screen}';
 }
 
 extension on window_size.Screen {
-  String customToString() => 'Screen{frame: $frame, visibleFrame: $visibleFrame, scaleFactor: $scaleFactor}';
+  String customToString() =>
+      'Screen{frame: $frame, visibleFrame: $visibleFrame, scaleFactor: $scaleFactor}';
 }

--- a/packages/convenient_test_manager/pubspec.yaml
+++ b/packages/convenient_test_manager/pubspec.yaml
@@ -28,8 +28,8 @@ dependencies:
   convenient_test_dev: ^1.0.0
   convenient_test_manager_dart: ^1.0.0
   cupertino_icons: ^1.0.2
-  dart_vlc: ^0.2.0
-  file_picker: ^4.5.1
+  dart_vlc: ^0.4.0
+  file_picker: ^5.2.4
   flutter:
     sdk: flutter
   flutter_mobx:


### PR DESCRIPTION
Because the current version of the VLC plug-in (0.4.0) [removes support for MacOS](https://github.com/alexmercerind/dart_vlc/issues/242). Relate #303