### PR TITLE
Upgrade `image` package to `4.0.0` for `convenient_test_dev`

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/goldens.dart
+++ b/packages/convenient_test_dev/lib/src/functions/goldens.dart
@@ -138,8 +138,8 @@ Uint8List _cropImage(Uint8List raw, Rectangle<int>? bbox) {
   if (bbox == null) return raw;
 
   final rawImage = image.decodeImage(raw)!;
-  final croppedImage = image.copyCrop(rawImage, bbox.left, bbox.top, bbox.width, bbox.height);
-  return image.encodePng(croppedImage) as Uint8List;
+  final croppedImage = image.copyCrop(rawImage, x: bbox.left, y: bbox.top, width: bbox.width, height: bbox.height);
+  return image.encodePng(croppedImage);
 }
 
 Future<MyComparisonResult> _compareListsAllowSizeDiffer(List<int> test, List<int> master) async {
@@ -157,16 +157,16 @@ Future<MyComparisonResult> _compareListsAllowSizeDiffer(List<int> test, List<int
 
 Future<MyComparisonResult> _compareListsGivenSizeDiffer(
     List<int> testRaw, List<int> masterRaw, ComparisonResult rawResult) async {
-  final testRawImage = image.decodeImage(testRaw)!;
-  final masterRawImage = image.decodeImage(masterRaw)!;
+  final testRawImage = image.decodeImage(Uint8List.fromList(testRaw))!;
+  final masterRawImage = image.decodeImage(Uint8List.fromList(masterRaw))!;
 
   final targetWidth = max(testRawImage.width, masterRawImage.width);
   final targetHeight = max(testRawImage.height, masterRawImage.height);
 
   List<int> padAndEncode(image.Image src) {
-    final dst = image.Image(targetWidth, targetHeight);
-    image.copyInto(dst, src, blend: false);
-    return image.encodeNamedImage(dst, 'temp.png')!;
+    final dst = image.Image(width: targetWidth, height: targetHeight);
+    image.compositeImage(dst, src, blend: image.BlendMode.direct);
+    return image.encodeNamedImage('temp.png', dst)!;
   }
 
   final testTarget = padAndEncode(testRawImage);

--- a/packages/convenient_test_dev/pubspec.yaml
+++ b/packages/convenient_test_dev/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   freezed_annotation: ^2.0.0
   get_it: ^7.0.0
   grpc: ^3.0.0
-  image: ^3.1.3
+  image: ^4.0.0
   integration_test:
     sdk: flutter
   intl: ^0.17.0


### PR DESCRIPTION
Closes #315

I don't have a project to test this on, but the goldens test in `convenient_test_dev` passed.