### PR TITLE
tTestWidgets: Forward the timeout argument

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/core.dart
+++ b/packages/convenient_test_dev/lib/src/functions/core.dart
@@ -171,6 +171,7 @@ void tTestWidgets(
   TWidgetTesterCallback callback, {
   bool skip = false,
   bool settle = true,
+  Timeout? timeout,
 }) {
   testWidgets(
     description,
@@ -187,5 +188,6 @@ void tTestWidgets(
       debugDefaultTargetPlatformOverride = null;
     }),
     skip: skip,
+    timeout: timeout,
   );
 }


### PR DESCRIPTION
Some of my tests seem to be getting stuck.