### PR TITLE
prevent convenient_test_manager_dart runs forever when an assertion error occurs

### DIFF
--- a/packages/convenient_test_dev/lib/src/functions/test_widgets.dart
+++ b/packages/convenient_test_dev/lib/src/functions/test_widgets.dart
@@ -31,12 +31,18 @@ void tTestWidgets(
       addTearDown(() => convenientTestLog('END', '', type: LogSubEntryType.TEST_END));
       // t.log('START APP', '');
 
+      // store original onError -> required for proper failure & exception handling (see https://github.com/flutter/flutter/issues/34499)
+      final FlutterExceptionHandler? originalOnError = FlutterError.onError;
+
       await tester.runAsync(() async {
         await myGetIt.get<ConvenientTestSlot>().appMain(AppMainExecuteMode.integrationTest);
       });
       settle ? await t.tester.pumpAndSettleWithRunAsync() : await t.tester.pumpWithRunAsync();
       // https://github.com/fzyzcjy/yplusplus/issues/8470#issuecomment-1528784564
       // await log.snapshot(name: 'after');
+
+      // reset onError after calling pumpAndSettle() -> required for proper failure & exception handling (see https://github.com/flutter/flutter/issues/34499)
+      FlutterError.onError = originalOnError;
 
       await callback(t);
 


### PR DESCRIPTION
This commit fixes convenient_test_manager_dart running forever when an assertion error occurs (see discussion https://github.com/fzyzcjy/flutter_convenient_test/discussions/350). Solution https://github.com/flutter/flutter/issues/34499#issuecomment-1381789793 was applied. Having tested everything locally with `convenient_test_manager_dart` and now the process terminates properly on failure. In addition, neither in the UI manager nor in the CLI app produced reports are any of these annoying exceptions
```
2023-10-30T14:28:48.791420Z|debug|ReportHandlerService|Error: 'package:flutter_test/src/binding.dart': Failed assertion: line 950 pos 14: '_pendingExceptionDetails != null': A test overrode FlutterError.onError but either failed to return it to its original state, or had unexpected additional errors that it could not handle. Typically, this is caused by using expect() before restoring FlutterError.onError. stack=dart:core-patch/errors_patch.dart 51:61       _AssertionError._doThrowNew
```
left after applying this patch.