### PR TITLE
Update DelegatingFinder for flutter 3.16.2

### DIFF
--- a/packages/convenient_test_dev/lib/src/utils/util.dart
+++ b/packages/convenient_test_dev/lib/src/utils/util.dart
@@ -5,15 +5,33 @@ import 'package:test_api/src/backend/state.dart'; // ignore_for_file: implementa
 
 class DelegatingFinder implements Finder {
   final Finder target;
+  @Deprecated('Use FinderBase.describeMatch instead. '
+      'FinderBase.describeMatch allows for more readable descriptions and removes ambiguity about pluralization. '
+      'This feature was deprecated after v3.13.0-0.2.pre.')
   final String? overrideDescription;
+  final String Function(Plurality)? overrideDescribeMatch;
 
-  DelegatingFinder(this.target, {this.overrideDescription});
+  DelegatingFinder(
+    this.target, {
+    @Deprecated('Use FinderBase.describeMatch instead. '
+        'FinderBase.describeMatch allows for more readable descriptions and removes ambiguity about pluralization. '
+        'This feature was deprecated after v3.13.0-0.2.pre.')
+    this.overrideDescription,
+    this.overrideDescribeMatch,
+  });
 
   @override
+  @Deprecated('Use FinderBase.describeMatch instead. '
+      'FinderBase.describeMatch allows for more readable descriptions and removes ambiguity about pluralization. '
+      'This feature was deprecated after v3.13.0-0.2.pre.')
   String get description => overrideDescription ?? target.description;
 
   @override
-  Iterable<Element> apply(Iterable<Element> candidates) => target.apply(candidates);
+  @Deprecated('Override FinderBase.findInCandidates instead. '
+      'Using the FinderBase API allows for more consistent caching behavior and cleaner options for interacting with the widget tree. '
+      'This feature was deprecated after v3.13.0-0.2.pre.')
+  Iterable<Element> apply(Iterable<Element> candidates) =>
+      target.apply(candidates);
 
   @override
   bool get skipOffstage => target.skipOffstage;
@@ -22,9 +40,12 @@ class DelegatingFinder implements Finder {
   Iterable<Element> get allCandidates => target.allCandidates;
 
   @override
-  Iterable<Element> evaluate() => target.evaluate();
+  FinderResult<Element> evaluate() => target.evaluate();
 
   @override
+  @Deprecated('Use FinderBase.tryFind or FinderBase.runCached instead. '
+      'Using the FinderBase API allows for more consistent caching behavior and cleaner options for interacting with the widget tree. '
+      'This feature was deprecated after v3.13.0-0.2.pre.')
   bool precache() => target.precache();
 
   @override
@@ -37,10 +58,35 @@ class DelegatingFinder implements Finder {
   Finder at(int index) => target.at(index);
 
   @override
-  Finder hitTestable({Alignment at = Alignment.center}) => target.hitTestable(at: at);
+  Finder hitTestable({Alignment at = Alignment.center}) =>
+      target.hitTestable(at: at);
 
   @override
-  String toString() => target.toString();
+  String toString({bool describeSelf = false}) =>
+      target.toString(describeSelf: describeSelf);
+
+  @override
+  String describeMatch(Plurality plurality) =>
+      overrideDescribeMatch?.call(plurality) ?? target.describeMatch(plurality);
+
+  @override
+  Iterable<Element> findInCandidates(Iterable<Element> candidates) =>
+      target.findInCandidates(candidates);
+
+  @override
+  FinderResult<Element> get found => target.found;
+
+  @override
+  bool get hasFound => target.hasFound;
+
+  @override
+  void reset() => target.reset();
+
+  @override
+  void runCached(VoidCallback run) => target.runCached(run);
+
+  @override
+  bool tryEvaluate() => target.tryEvaluate();
 }
 
 extension ExtState on State {


### PR DESCRIPTION
When building `convenient_test_manager` for Windows on master I get the following error message:

```
> flutter build windows

../convenient_test_dev/lib/src/utils/util.dart(6,7): error G76B49859: The non-abstract class 'DelegatingFinder' is missing implementations for these members: [...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\flutter\flutter_assemble.vcxproj]
../convenient_test_dev/lib/src/utils/util.dart(25,21): error G0A556F40: The return type of the method 'DelegatingFinder.evaluate' is 'Iterable<Element>', which does not match the return type, 'FinderResult<Element>', of the overridden method, 'FinderBase.evaluate'. [...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\flutter\flutter_assemble.vcxproj]
../convenient_test_dev/lib/src/utils/util.dart(43,10): error GE5CFE876: The method 'DelegatingFinder.toString' has fewer named arguments than those of overridden method 'FinderBase.toString'. [...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\flutter\flutter_assemble.vcxproj]
...\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for '...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\CMakeFiles\ded4cdf977ef776379c919ab64e04105\flutter_windows.dll.rule;...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\CMakeFiles\bcf9c5332835a00d3f9f7d34f711e896\flutter_assemble.rule' exited with code 1. [...\flutter_convenient_test\packages\convenient_test_manager\build\windows\x64\flutter\flutter_assemble.vcxproj]
Building Windows application...                                    22,4s
Build process failed.
```

Looking into `DelegatingFinder` some methods are incompatible with what I assume were changes introduced in flutter 3.13.0.

I have fixed and extended the class while trying to retain its purpose. With these changes, I am able to build and run the manager as expected, though I have not fully tested it.