### PR TITLE
Using darker background for error text in dark mode

### DIFF
--- a/packages/convenient_test_manager/lib/components/home_page/log_entry_widget.dart
+++ b/packages/convenient_test_manager/lib/components/home_page/log_entry_widget.dart
@@ -226,7 +226,9 @@ class HomePageLogEntryWidget extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
         margin: const EdgeInsets.only(left: 32),
         decoration: BoxDecoration(
-          color: Colors.red[50],
+          color: Theme.of(context).brightness == Brightness.light //
+              ? Colors.red.shade50
+              : const Color(0xFF6C2827),
           border: Border(left: BorderSide(color: Colors.red[200]!, width: 2)),
         ),
         child: Column(


### PR DESCRIPTION
Currently, error text is displayed as white text on a light red background, which is very difficult to read. This PR just changes the background color to a darker red when the app is in dark mode. I personally found the darker shades of `Colors.red` too saturated for this use case, so created an arbitrary shade of dark red to use instead. I have no objections if you want to change the shade of red, I just want the text to be legible. You can find before/after screenshots attached below.

<details><summary>Before</summary>
<p>

<img width="771" alt="Screenshot 2024-01-09 at 11 35 30" src="https://github.com/fzyzcjy/flutter_convenient_test/assets/1316184/fcd42464-561c-449b-b81e-7a12430d78ff">

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="780" alt="Screenshot 2024-01-09 at 11 36 07" src="https://github.com/fzyzcjy/flutter_convenient_test/assets/1316184/ab2caa80-39d9-469c-92bc-575c653c3f30">

</p>
</details> 
