### PR TITLE
fix(ci): build_manager_macos-ci-job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.7.0"
-          bundler-cache: false
+          bundler-cache: true
 
       - name: setup-cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         working-directory: packages/${{ matrix.package_name_and_runs_on.package_name }}
 
   build_manager_macos:
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,48 +53,48 @@ jobs:
         run: dart format --set-exit-if-changed .
         working-directory: packages/${{ matrix.package_name_and_runs_on.package_name }}
 
- build_manager_macos:
-   runs-on: macos-11
+  build_manager_macos:
+    runs-on: macos-11
 
-   steps:
-     - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
-     - uses: subosito/flutter-action@v2
-       with:
+      - uses: subosito/flutter-action@v2
+        with:
          channel: stable
 
-     - name: Enable Macos
-       run: flutter config --enable-macos-desktop
+      - name: Enable Macos
+        run: flutter config --enable-macos-desktop
 
-     - name: Install dependencies
-       run: flutter pub get
-       working-directory: packages/convenient_test_manager
+      - name: Install dependencies
+        run: flutter pub get
+        working-directory: packages/convenient_test_manager
 
-     - uses: ruby/setup-ruby@v1
-       with:
-         ruby-version: "2.7.0"
-         bundler-cache: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7.0"
+          bundler-cache: false
 
-     - name: setup-cocoapods
-       uses: maxim-lobanov/setup-cocoapods@v1
-       with:
-         version: latest
+      - name: setup-cocoapods
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: latest
 
-     - name: flutter build
-       run: flutter build macos
-       working-directory: packages/convenient_test_manager/macos
+      - name: flutter build
+        run: flutter build macos
+        working-directory: packages/convenient_test_manager/macos
 
-     - name: build_mac_app
-       run: bundle install && bundle exec fastlane run build_mac_app export_method:mac-application scheme:Runner output_directory:./build
-       working-directory: packages/convenient_test_manager/macos
+      - name: build_mac_app
+        run: bundle install && bundle exec fastlane run build_mac_app export_method:mac-application scheme:Runner output_directory:./build
+        working-directory: packages/convenient_test_manager/macos
 
-     - name: Tar outputs
-       run: cd packages/convenient_test_manager/macos/build && tar cvf convenient_test_manager.app.tar convenient_test_manager.app
+      - name: Tar outputs
+        run: cd packages/convenient_test_manager/macos/build && tar cvf convenient_test_manager.app.tar convenient_test_manager.app
 
-     - uses: actions/upload-artifact@v3
-       with:
-         name: manager_macos
-         path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
+      - uses: actions/upload-artifact@v3
+        with:
+          name: manager_macos
+          path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
 
   build_manager_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ TODO fix it (seems GitHub Actions upgraded, making Fastlane confused)
      - uses: ruby/setup-ruby@v1
        with:
          ruby-version: "2.7.0"
-         bundler-cache: true
+         bundler-cache: false
 
      - name: setup-cocoapods
        uses: maxim-lobanov/setup-cocoapods@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,49 +53,49 @@ jobs:
         run: dart format --set-exit-if-changed .
         working-directory: packages/${{ matrix.package_name_and_runs_on.package_name }}
 
-# TODO fix it (seems GitHub Actions upgraded, making Fastlane confused)
-#  build_manager_macos:
-#    runs-on: macos-11
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#
-#      - uses: subosito/flutter-action@v2
-#        with:
-#          channel: stable
-#
-#      - name: Enable Macos
-#        run: flutter config --enable-macos-desktop
-#
-#      - name: Install dependencies
-#        run: flutter pub get
-#        working-directory: packages/convenient_test_manager
-#
-#      - uses: ruby/setup-ruby@v1
-#        with:
-#          ruby-version: "2.7.0"
-#          bundler-cache: true
-#
-#      - name: setup-cocoapods
-#        uses: maxim-lobanov/setup-cocoapods@v1
-#        with:
-#          version: latest
-#
-#      - name: flutter build
-#        run: flutter build macos
-#        working-directory: packages/convenient_test_manager/macos
-#
-#      - name: build_mac_app
-#        run: bundle install && bundle exec fastlane run build_mac_app export_method:mac-application scheme:Runner output_directory:./build
-#        working-directory: packages/convenient_test_manager/macos
-#
-#      - name: Tar outputs
-#        run: cd packages/convenient_test_manager/macos/build && tar cvf convenient_test_manager.app.tar convenient_test_manager.app
-#
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: manager_macos
-#          path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
+TODO fix it (seems GitHub Actions upgraded, making Fastlane confused)
+ build_manager_macos:
+   runs-on: macos-11
+
+   steps:
+     - uses: actions/checkout@v3
+
+     - uses: subosito/flutter-action@v2
+       with:
+         channel: stable
+
+     - name: Enable Macos
+       run: flutter config --enable-macos-desktop
+
+     - name: Install dependencies
+       run: flutter pub get
+       working-directory: packages/convenient_test_manager
+
+     - uses: ruby/setup-ruby@v1
+       with:
+         ruby-version: "2.7.0"
+         bundler-cache: true
+
+     - name: setup-cocoapods
+       uses: maxim-lobanov/setup-cocoapods@v1
+       with:
+         version: latest
+
+     - name: flutter build
+       run: flutter build macos
+       working-directory: packages/convenient_test_manager/macos
+
+     - name: build_mac_app
+       run: bundle install && bundle exec fastlane run build_mac_app export_method:mac-application scheme:Runner output_directory:./build
+       working-directory: packages/convenient_test_manager/macos
+
+     - name: Tar outputs
+       run: cd packages/convenient_test_manager/macos/build && tar cvf convenient_test_manager.app.tar convenient_test_manager.app
+
+     - uses: actions/upload-artifact@v3
+       with:
+         name: manager_macos
+         path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
 
   build_manager_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,6 @@ jobs:
         run: dart format --set-exit-if-changed .
         working-directory: packages/${{ matrix.package_name_and_runs_on.package_name }}
 
-TODO fix it (seems GitHub Actions upgraded, making Fastlane confused)
  build_manager_macos:
    runs-on: macos-11
 

--- a/packages/convenient_test_manager/macos/.bundle/config
+++ b/packages/convenient_test_manager/macos/.bundle/config
@@ -1,1 +1,0 @@
-BUNDLE_PATH: "../.gems"

--- a/packages/convenient_test_manager/macos/.bundle/config
+++ b/packages/convenient_test_manager/macos/.bundle/config
@@ -1,0 +1,1 @@
+BUNDLE_PATH: "../.gems"


### PR DESCRIPTION
closes #380

**Changes:**

- Enables the `build_manager_macos` github actions job and changes to the `macos-latest` build runner for this job