### PR TITLE
Bump github actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           # see https://github.com/fzyzcjy/flutter_convenient_test/pull/319#issuecomment-1445048397
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
@@ -57,7 +57,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
@@ -91,7 +91,7 @@ jobs:
       - name: Tar outputs
         run: cd packages/convenient_test_manager/macos/build && tar cvf convenient_test_manager.app.tar convenient_test_manager.app
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: manager_macos
           path: packages/convenient_test_manager/macos/build/convenient_test_manager.app.tar
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
@@ -124,7 +124,7 @@ jobs:
       - name: Tar outputs
         run: tar -czvf convenient_test_manager.tar.gz -C packages/convenient_test_manager/build/linux/x64/release/ bundle
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: manager_linux
           path: convenient_test_manager.tar.gz
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
@@ -147,7 +147,7 @@ jobs:
         run: dart compile exe bin/convenient_test_manager_dart.dart -o convenient_test_manager_dart
         working-directory: packages/convenient_test_manager_dart
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: manager_dart_linux
           path: packages/convenient_test_manager_dart/convenient_test_manager_dart

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -20,7 +20,7 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
old versions are deprecated and to be removed.

see https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/